### PR TITLE
Added support for @throws

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ logs
 results
 
 npm-debug.log
+
+.idea


### PR DESCRIPTION
It is now possible to expect an error by using the following syntax:

```
// @describe validate-ident()

// @it Validate standard ident
validate-ident('hello') is true
// @throws
```

This test will now fail unless call to validate-ident throws an error.

It is possible to provide a regex to test the error message by using:

```
// @throws /This is my error testing regex/
```

The code is not the cleanest and can certainly be refactored should more annotations be added (eg. @shouldNotThrow), but it does the job.
